### PR TITLE
Add CONTAINER_MEMORY_LIMIT to config.ts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,8 @@ export const MAIN_GROUP_FOLDER = 'main';
 
 export const CONTAINER_IMAGE =
   process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';
+export const CONTAINER_MEMORY_LIMIT =
+  process.env.CONTAINER_MEMORY_LIMIT || '512m';
 export const CONTAINER_TIMEOUT = parseInt(
   process.env.CONTAINER_TIMEOUT || '1800000',
   10,


### PR DESCRIPTION
Fixes #4

Adds `CONTAINER_MEMORY_LIMIT` config constant with default value `512m`, configurable via environment variable.

Auto-generated by Claude Issue Fixer.